### PR TITLE
get it to compile by using collections_bound trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(alloc)]
 #![feature(collections)]
 #![feature(inclusive_range)]
+#![feature(collections_bound)]
 #![feature(specialization)]
 #![feature(heap_api)]
 #![feature(shared)]


### PR DESCRIPTION
It wont compile on 1.17-nightly unless this feature is enabled.